### PR TITLE
example action to get Ringer vol  was displayed incorrect

### DIFF
--- a/_docs/2 Actions/I Volume.md
+++ b/_docs/2 Actions/I Volume.md
@@ -10,7 +10,7 @@ sublinks: ["volume.getRinger()", "volume.setRinger()", "volume.getMedia()", "vol
 ## volume.getRinger() ##
 #### Syntax
 ```js
-var ringVolume = volume.getLevel();
+var ringVolume = volume.getRinger();
 ```
 
 #### Return value


### PR DESCRIPTION
Documentation example was
var ringVolume = volume.getLevel();
####
updated example should be
var ringVolume = volume.getRinger();